### PR TITLE
support Qt5

### DIFF
--- a/ScopeWindow.cxx
+++ b/ScopeWindow.cxx
@@ -30,9 +30,9 @@ ScopeWindow::ScopeWindow(const char* sourcename)
     for(int ch=0; ch < ScopeWidget::N_CHANNELS; ch++) {
         makeChannelCfg(l1, ch, enableMapper, scaleMapper, offsetMapper);
     }
-    connect(enableMapper, SIGNAL(mapped(int)), this, SLOT(channelEnableChanged(int)));
-    connect(scaleMapper, SIGNAL(mapped(int)), this, SLOT(channelScaleChanged(int)));
-    connect(offsetMapper, SIGNAL(mapped(int)), this, SLOT(channelOffsetChanged(int)));
+    connect(enableMapper, SIGNAL(mappedInt(int)), this, SLOT(channelEnableChanged(int)));
+    connect(scaleMapper, SIGNAL(mappedInt(int)), this, SLOT(channelScaleChanged(int)));
+    connect(offsetMapper, SIGNAL(mappedInt(int)), this, SLOT(channelOffsetChanged(int)));
     
     l1->setColumnMinimumWidth(fScopeWidget->N_CHANNELS, 40);
     makeTimeCfg(l1, fScopeWidget->N_CHANNELS + 1);
@@ -97,7 +97,7 @@ void ScopeWindow::makeChannelCfg(QGridLayout* l, int ch, QSignalMapper* enableMa
 {
     QWidget* bar = new QWidget();
     QPalette p;
-    p.setColor(QPalette::Background, fScopeWidget->channel(ch)->color());
+    p.setColor(QPalette::Window, fScopeWidget->channel(ch)->color());
     bar->setAutoFillBackground(true);
     bar->setPalette(p);
     bar->setFixedHeight(8);
@@ -138,7 +138,7 @@ void ScopeWindow::makeTimeCfg(QGridLayout* l, int col)
 {
     QWidget* bar = new QWidget();
     QPalette p;
-    p.setColor(QPalette::Background, Qt::white);
+    p.setColor(QPalette::Window, Qt::white);
     bar->setAutoFillBackground(true);
     bar->setPalette(p);
     bar->setFixedHeight(8);

--- a/softscope.pro
+++ b/softscope.pro
@@ -1,4 +1,5 @@
 HEADERS = Channel.h DataReader.h RawDataReader.h ScopeWindow.h ScopeWidget.h
 SOURCES = softscope.cxx RawDataReader.cxx ScopeWindow.cxx ScopeWidget.cxx
+QT += widgets
 # QMAKE_CXXFLAGS += -pg
 # QMAKE_LFLAGS += -pg


### PR DESCRIPTION
Softscope uses QtWidgets, but Qt5 splits this off into a module[1]. Pull
the module in explicitly to make it build again.

[1] https://wiki.qt.io/Transition_from_Qt_4.x_to_Qt5